### PR TITLE
Add support for the Parrot Mars drone

### DIFF
--- a/js/drone.js
+++ b/js/drone.js
@@ -110,6 +110,7 @@ let ParrotDrone = function() {
     return navigator.bluetooth.requestDevice({
         filters: [
           { namePrefix: 'RS_' },
+          { namePrefix: 'Mars_' },
           { namePrefix: 'Travis_'}
         ],
         optionalServices: [


### PR DESCRIPTION
Okay, basically just add the prefix Mars_, because otherwise it works just fine.