### PR TITLE
Include drones prefixed with "Mambo_" during scan

### DIFF
--- a/js/drone.v1.2.js
+++ b/js/drone.v1.2.js
@@ -111,6 +111,7 @@ let ParrotDrone = function() {
         filters: [
           { namePrefix: 'RS_' },
           { namePrefix: 'Mars_' },
+          { namePrefix: 'Mambo_' },
           { namePrefix: 'Travis_'}
         ],
         optionalServices: [


### PR DESCRIPTION
Hi poshaughnessy,

I have a drone starting with this name prefix that works with the web app, but it is filtered out. This change just updates the filters to include the "Mambo_" name prefix.